### PR TITLE
Add SWT vs AWT and numerous other flags to experiment with different settings

### DIFF
--- a/org.dawnsci.january.to.jzy3d/src/org/dawnsci/january/to/jzy3d/parts/JZY3DPart.java
+++ b/org.dawnsci.january.to.jzy3d/src/org/dawnsci/january/to/jzy3d/parts/JZY3DPart.java
@@ -11,7 +11,6 @@ package org.dawnsci.january.to.jzy3d.parts;
 import java.awt.Component;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -30,47 +29,104 @@ import org.eclipse.january.dataset.IDataset;
 import org.eclipse.january.dataset.ILazyDataset;
 import org.eclipse.january.dataset.SliceND;
 import org.eclipse.swt.layout.FillLayout;
-import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.jzy3d.bridge.swt.Bridge;
 import org.jzy3d.chart.Chart;
+import org.jzy3d.chart.ChartLauncher;
 import org.jzy3d.chart.Settings;
 import org.jzy3d.chart.factories.AWTChartComponentFactory;
+import org.jzy3d.chart.swt.SWTChartComponentFactory;
 import org.jzy3d.colors.Color;
 import org.jzy3d.colors.ColorMapper;
 import org.jzy3d.colors.colormaps.ColorMapRBG;
+import org.jzy3d.colors.colormaps.ColorMapRainbow;
 import org.jzy3d.maths.Coord3d;
+import org.jzy3d.maths.Range;
+import org.jzy3d.plot3d.builder.Builder;
+import org.jzy3d.plot3d.builder.Mapper;
+import org.jzy3d.plot3d.builder.concrete.OrthonormalGrid;
 import org.jzy3d.plot3d.primitives.Point;
 import org.jzy3d.plot3d.primitives.Polygon;
 import org.jzy3d.plot3d.primitives.Shape;
 import org.jzy3d.plot3d.rendering.canvas.Quality;
 
 public class JZY3DPart {
+	/**
+	 * Quality of rendering. See {@link Quality} for options.
+	 */
+	private static final Quality QUALITY = Quality.Intermediate;
+
+	/**
+	 * Turn on or off Hardware Acceleration
+	 */
+	private static final boolean HARDWARE_ACCELERATED = true;
+
+	/**
+	 * Use a diffraction pattern provided by a jpg in this bundle, or if false, use
+	 * a Sin wave.
+	 */
+	private static final boolean USE_DIFFPATTERN = false;
+
+	/**
+	 * Use a SWTChartComponentFactory vs AWTChartComponentFactory as the drawing
+	 * canvas.
+	 */
+	private static final boolean USE_SWT = true;
 
 	private Composite parent;
-
-	private String filename;
 
 	@PostConstruct
 	public void createComposite(Composite parent) {
 		this.parent = parent;
-		parent.setLayout(new GridLayout(1, false));
+		parent.setLayout(new FillLayout());
 
-		// if (filename == null) {
-		// Shell shell = Display.getDefault().getActiveShell();
-		// FileDialog dialog = new FileDialog(shell);
-		// filename = dialog.open();
-		// }
+		Shape surface;
+		if (USE_DIFFPATTERN) {
+			surface = createSurfaceDiffpattern();
+		} else {
+			surface = createSurfaceSin();
+		}
+
+		if (USE_SWT) {
+			drawSurfaceSWTChartComponentFactory(surface, parent);
+		} else {
+			drawSurfaceAWTChartComponentFactory(surface, parent);
+		}
+	}
+
+	private Shape createSurfaceDiffpattern() {
+		Shape surface = null;
 		URL url = FileLocator.find(Activator.getContext().getBundle(), new Path("data/diffpattern2.jpg"), null);
 		try {
 			url = FileLocator.toFileURL(url);
-			filename = URIUtil.toFile(URIUtil.toURI(url)).toString();
-			Shape surface = getSurfaceFromImage(filename);
-			drawSurface(surface, parent);
+			String filename = URIUtil.toFile(URIUtil.toURI(url)).toString();
+			surface = getSurfaceFromImage(filename);
 		} catch (IOException | URISyntaxException e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
+		return surface;
+	}
+
+	private Shape createSurfaceSin() {
+		Mapper mapper = new Mapper() {
+			@Override
+			public double f(double x, double y) {
+				return x * Math.sin(x * y);
+			}
+		};
+
+		// Define range and precision for the function to plot
+		Range range = new Range(-3, 3);
+		int steps = 80;
+
+		// Create the object to represent the function over the given range.
+		final Shape surface = Builder.buildOrthonormal(new OrthonormalGrid(range, steps, range, steps), mapper);
+		surface.setColorMapper(new ColorMapper(new ColorMapRainbow(), surface.getBounds().getZmin(),
+				surface.getBounds().getZmax(), new Color(1, 1, 1, .5f)));
+		surface.setFaceDisplayed(true);
+		surface.setWireframeDisplayed(false);
+		return surface;
 	}
 
 	/*
@@ -109,28 +165,25 @@ public class JZY3DPart {
 			}
 		}
 		// create a shape with the polygons
-		return new Shape(polygons);
-	}
-
-	/**
-	 * Draw a surface on a JZy3d chart inside of a SWT Composite
-	 *
-	 * @param surface
-	 * @param parent
-	 */
-	private void drawSurface(Shape surface, Composite parent) {
+		Shape surface = new Shape(polygons);
 		surface.setColorMapper(new ColorMapper(new ColorMapRBG(), surface.getBounds().getZmin(),
 				surface.getBounds().getZmax(), new Color(1, 1, 1, .5f)));
 		surface.setFaceDisplayed(true);
 		surface.setWireframeDisplayed(false);
+		return surface;
+	}
 
-		// Create a chart
-		Chart chart = AWTChartComponentFactory.chart(Quality.Advanced, "awt");
+	private void drawSurfaceSWTChartComponentFactory(Shape surface, Composite parent) {
+		Chart chart = SWTChartComponentFactory.chart(parent, QUALITY);
 		chart.getScene().getGraph().add(surface);
+		Settings.getInstance().setHardwareAccelerated(HARDWARE_ACCELERATED);
+		ChartLauncher.openChart(chart);
+	}
 
-		Settings.getInstance().setHardwareAccelerated(true);
-
-		parent.setLayout(new FillLayout());
+	private void drawSurfaceAWTChartComponentFactory(Shape surface, Composite parent) {
+		Chart chart = AWTChartComponentFactory.chart(QUALITY, "awt");
+		chart.getScene().getGraph().add(surface);
+		Settings.getInstance().setHardwareAccelerated(HARDWARE_ACCELERATED);
 		chart.addKeyboardCameraController();
 		chart.addKeyboardScreenshotController();
 		chart.addMouseCameraController();


### PR DESCRIPTION
At the top of JZY3DPart there are now some constants that control which engine is used and some of the settings. The SWT version is based on SWTDemo as requested by Jake.

Note you need to reload the target platform to get my fix for SWT in Jogl. Without the fix you get exception that look like this first:

```

!ENTRY org.eclipse.e4.ui.workbench.swt 4 2 2018-01-10 11:42:35.553
!MESSAGE Problems occurred when invoking code from plug-in: "org.eclipse.e4.ui.workbench.swt".
!STACK 0
java.lang.ExceptionInInitializerError
	at com.jogamp.newt.swt.NewtCanvasSWT.<init>(NewtCanvasSWT.java:127)
	at org.jzy3d.chart.swt.CanvasNewtSWT.<init>(CanvasNewtSWT.java:51)
	at org.jzy3d.chart.swt.SWTChartComponentFactory.newCanvas(SWTChartComponentFactory.java:129)
	at org.jzy3d.chart.factories.ChartComponentFactory.newCanvas(ChartComponentFactory.java:222)
	at org.jzy3d.chart.Chart.<init>(Chart.java:79)
	at org.jzy3d.chart.Chart.<init>(Chart.java:65)
	at org.jzy3d.chart.swt.SWTChart.<init>(SWTChart.java:13)
	at org.jzy3d.chart.swt.SWTChartComponentFactory.newChart(SWTChartComponentFactory.java:66)
	at org.jzy3d.chart.factories.ChartComponentFactory.newChart(ChartComponentFactory.java:67)
	at org.jzy3d.chart.swt.SWTChartComponentFactory.chart(SWTChartComponentFactory.java:56)
	at org.dawnsci.january.to.jzy3d.parts.JZY3DPart.drawSurfaceSWTChartComponentFactory(JZY3DPart.java:177)
	at org.dawnsci.january.to.jzy3d.parts.JZY3DPart.createComposite(JZY3DPart.java:91)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.eclipse.e4.core.internal.di.MethodRequestor.execute(MethodRequestor.java:55)
	at org.eclipse.e4.core.internal.di.InjectorImpl.processAnnotated(InjectorImpl.java:966)
	at org.eclipse.e4.core.internal.di.InjectorImpl.inject(InjectorImpl.java:151)
	at org.eclipse.e4.core.internal.di.InjectorImpl.internalMake(InjectorImpl.java:375)
	at org.eclipse.e4.core.internal.di.InjectorImpl.make(InjectorImpl.java:294)
	at org.eclipse.e4.core.contexts.ContextInjectionFactory.make(ContextInjectionFactory.java:162)
	at org.eclipse.e4.ui.internal.workbench.ReflectionContributionFactory.createFromBundle(ReflectionContributionFactory.java:105)
	at org.eclipse.e4.ui.internal.workbench.ReflectionContributionFactory.doCreate(ReflectionContributionFactory.java:74)
	at org.eclipse.e4.ui.internal.workbench.ReflectionContributionFactory.create(ReflectionContributionFactory.java:56)
	at org.eclipse.e4.ui.workbench.renderers.swt.ContributedPartRenderer.createWidget(ContributedPartRenderer.java:129)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.createWidget(PartRenderingEngine.java:975)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.safeCreateGui(PartRenderingEngine.java:651)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.safeCreateGui(PartRenderingEngine.java:757)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.access$0(PartRenderingEngine.java:728)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$2.run(PartRenderingEngine.java:722)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:42)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.createGui(PartRenderingEngine.java:706)
	at org.eclipse.e4.ui.workbench.renderers.swt.StackRenderer.showTab(StackRenderer.java:1317)
	at org.eclipse.e4.ui.workbench.renderers.swt.LazyStackRenderer.postProcess(LazyStackRenderer.java:103)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.safeCreateGui(PartRenderingEngine.java:669)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.safeCreateGui(PartRenderingEngine.java:757)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.access$0(PartRenderingEngine.java:728)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$2.run(PartRenderingEngine.java:722)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:42)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.createGui(PartRenderingEngine.java:706)
	at org.eclipse.e4.ui.workbench.renderers.swt.SWTPartRenderer.processContents(SWTPartRenderer.java:70)
	at org.eclipse.e4.ui.workbench.renderers.swt.SashRenderer.processContents(SashRenderer.java:142)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.safeCreateGui(PartRenderingEngine.java:665)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.safeCreateGui(PartRenderingEngine.java:757)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.access$0(PartRenderingEngine.java:728)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$2.run(PartRenderingEngine.java:722)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:42)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.createGui(PartRenderingEngine.java:706)
	at org.eclipse.e4.ui.workbench.renderers.swt.SWTPartRenderer.processContents(SWTPartRenderer.java:70)
	at org.eclipse.e4.ui.workbench.renderers.swt.PerspectiveRenderer.processContents(PerspectiveRenderer.java:49)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.safeCreateGui(PartRenderingEngine.java:665)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.safeCreateGui(PartRenderingEngine.java:757)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.access$0(PartRenderingEngine.java:728)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$2.run(PartRenderingEngine.java:722)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:42)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.createGui(PartRenderingEngine.java:706)
	at org.eclipse.e4.ui.workbench.renderers.swt.PerspectiveStackRenderer.showTab(PerspectiveStackRenderer.java:82)
	at org.eclipse.e4.ui.workbench.renderers.swt.LazyStackRenderer.postProcess(LazyStackRenderer.java:103)
	at org.eclipse.e4.ui.workbench.renderers.swt.PerspectiveStackRenderer.postProcess(PerspectiveStackRenderer.java:63)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.safeCreateGui(PartRenderingEngine.java:669)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.safeCreateGui(PartRenderingEngine.java:757)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.access$0(PartRenderingEngine.java:728)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$2.run(PartRenderingEngine.java:722)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:42)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.createGui(PartRenderingEngine.java:706)
	at org.eclipse.e4.ui.workbench.renderers.swt.SWTPartRenderer.processContents(SWTPartRenderer.java:70)
	at org.eclipse.e4.ui.workbench.renderers.swt.WBWRenderer.processContents(WBWRenderer.java:725)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.safeCreateGui(PartRenderingEngine.java:665)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.safeCreateGui(PartRenderingEngine.java:757)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.access$0(PartRenderingEngine.java:728)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$2.run(PartRenderingEngine.java:722)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:42)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.createGui(PartRenderingEngine.java:706)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$4.run(PartRenderingEngine.java:1059)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:336)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1022)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:150)
	at org.eclipse.ui.internal.Workbench$5.run(Workbench.java:693)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:336)
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:610)
	at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:148)
	at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:138)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:196)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:134)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:104)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:388)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:243)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:673)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:610)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1519)
	at org.eclipse.equinox.launcher.Main.main(Main.java:1492)
Caused by: com.jogamp.nativewindow.NativeWindowException: com.jogamp.common.JogampRuntimeException: org.eclipse.swt.internal.gtk.OS not available
	at com.jogamp.nativewindow.swt.SWTAccessor.<clinit>(SWTAccessor.java:203)
	... 96 more
Caused by: com.jogamp.common.JogampRuntimeException: org.eclipse.swt.internal.gtk.OS not available
	at com.jogamp.common.util.ReflectionUtil.getClass(ReflectionUtil.java:173)
	at com.jogamp.nativewindow.swt.SWTAccessor.<clinit>(SWTAccessor.java:182)
	... 96 more
Caused by: java.lang.ClassNotFoundException: org.eclipse.swt.internal.gtk.OS cannot be found by org.jogamp.jogl.ebr_2.3.2.v20180110-1125
	at org.eclipse.osgi.internal.loader.BundleLoader.findClassInternal(BundleLoader.java:461)
	at org.eclipse.osgi.internal.loader.BundleLoader.findClass(BundleLoader.java:372)
	at org.eclipse.osgi.internal.loader.BundleLoader.findClass(BundleLoader.java:364)
	at org.eclipse.osgi.internal.loader.ModuleClassLoader.loadClass(ModuleClassLoader.java:161)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	at java.lang.Class.forName0(Native Method)
	at java.lang.Class.forName(Class.java:348)
	at com.jogamp.common.util.ReflectionUtil.getClassImpl(ReflectionUtil.java:149)
	at com.jogamp.common.util.ReflectionUtil.getClass(ReflectionUtil.java:171)
	... 97 more
```

followed by many instances of this:

```

!ENTRY org.eclipse.osgi 4 0 2018-01-10 11:42:35.583
!MESSAGE Application error
!STACK 1
java.lang.NoClassDefFoundError: Could not initialize class com.jogamp.nativewindow.swt.SWTAccessor
	at com.jogamp.newt.swt.NewtCanvasSWT.setBounds(NewtCanvasSWT.java:198)
	at org.eclipse.swt.layout.FillLayout.layout(FillLayout.java:204)
	at org.eclipse.swt.widgets.Composite.updateLayout(Composite.java:1744)
	at org.eclipse.swt.widgets.Composite.updateLayout(Composite.java:1750)
	at org.eclipse.swt.widgets.Composite.updateLayout(Composite.java:1750)
	at org.eclipse.swt.widgets.Composite.updateLayout(Composite.java:1750)
	at org.eclipse.swt.widgets.Composite.layout(Composite.java:1056)
	at org.eclipse.e4.ui.workbench.renderers.swt.SashRenderer.forceLayout(SashRenderer.java:83)
	at org.eclipse.e4.ui.workbench.renderers.swt.SashRenderer.processContents(SashRenderer.java:146)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.safeCreateGui(PartRenderingEngine.java:665)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.safeCreateGui(PartRenderingEngine.java:757)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.access$0(PartRenderingEngine.java:728)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$2.run(PartRenderingEngine.java:722)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:42)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.createGui(PartRenderingEngine.java:706)
	at org.eclipse.e4.ui.workbench.renderers.swt.SWTPartRenderer.processContents(SWTPartRenderer.java:70)
	at org.eclipse.e4.ui.workbench.renderers.swt.PerspectiveRenderer.processContents(PerspectiveRenderer.java:49)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.safeCreateGui(PartRenderingEngine.java:665)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.safeCreateGui(PartRenderingEngine.java:757)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.access$0(PartRenderingEngine.java:728)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$2.run(PartRenderingEngine.java:722)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:42)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.createGui(PartRenderingEngine.java:706)
	at org.eclipse.e4.ui.workbench.renderers.swt.PerspectiveStackRenderer.showTab(PerspectiveStackRenderer.java:82)
	at org.eclipse.e4.ui.workbench.renderers.swt.LazyStackRenderer.postProcess(LazyStackRenderer.java:103)
	at org.eclipse.e4.ui.workbench.renderers.swt.PerspectiveStackRenderer.postProcess(PerspectiveStackRenderer.java:63)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.safeCreateGui(PartRenderingEngine.java:669)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.safeCreateGui(PartRenderingEngine.java:757)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.access$0(PartRenderingEngine.java:728)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$2.run(PartRenderingEngine.java:722)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:42)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.createGui(PartRenderingEngine.java:706)
	at org.eclipse.e4.ui.workbench.renderers.swt.SWTPartRenderer.processContents(SWTPartRenderer.java:70)
	at org.eclipse.e4.ui.workbench.renderers.swt.WBWRenderer.processContents(WBWRenderer.java:725)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.safeCreateGui(PartRenderingEngine.java:665)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.safeCreateGui(PartRenderingEngine.java:757)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.access$0(PartRenderingEngine.java:728)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$2.run(PartRenderingEngine.java:722)
	at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:42)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.createGui(PartRenderingEngine.java:706)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine$4.run(PartRenderingEngine.java:1059)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:336)
	at org.eclipse.e4.ui.internal.workbench.swt.PartRenderingEngine.run(PartRenderingEngine.java:1022)
	at org.eclipse.e4.ui.internal.workbench.E4Workbench.createAndRunUI(E4Workbench.java:150)
	at org.eclipse.ui.internal.Workbench$5.run(Workbench.java:693)
	at org.eclipse.core.databinding.observable.Realm.runWithDefault(Realm.java:336)
	at org.eclipse.ui.internal.Workbench.createAndRunWorkbench(Workbench.java:610)
	at org.eclipse.ui.PlatformUI.createAndRunWorkbench(PlatformUI.java:148)
	at org.eclipse.ui.internal.ide.application.IDEApplication.start(IDEApplication.java:138)
	at org.eclipse.equinox.internal.app.EclipseAppHandle.run(EclipseAppHandle.java:196)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.runApplication(EclipseAppLauncher.java:134)
	at org.eclipse.core.runtime.internal.adaptor.EclipseAppLauncher.start(EclipseAppLauncher.java:104)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:388)
	at org.eclipse.core.runtime.adaptor.EclipseStarter.run(EclipseStarter.java:243)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.eclipse.equinox.launcher.Main.invokeFramework(Main.java:673)
	at org.eclipse.equinox.launcher.Main.basicRun(Main.java:610)
	at org.eclipse.equinox.launcher.Main.run(Main.java:1519)
	at org.eclipse.equinox.launcher.Main.main(Main.java:1492)
An error has occurred. See the log file
```
